### PR TITLE
feat: whitebox-controller as a go library

### DIFF
--- a/handler/common/common.go
+++ b/handler/common/common.go
@@ -39,6 +39,10 @@ func NewHandler(c *config.HandlerConfig) (handler.Handler, error) {
 		}
 	}
 
+	if c.Func != nil {
+		h = c.Func.Handler
+	}
+
 	if h == nil {
 		return nil, errors.New("no handler found")
 	}


### PR DESCRIPTION
Enhances whitebox-controller so that you can use it as a framework for building custom operators.

The only change I needed in order to build my own operator on top of whitebox-controller was to enahnce `HanderConfig` to accept a go function so that you can inject any go function to reconcilers, finalizers, and webhooks. So you don't need to shell-out!

An advanced use-case of this feature would be to provide the default handler as a go function, while allowing the user to inject any executable script or command to be used if needed. You get the efficiency and the power of go functions in addition to the easiness and the extensibility provided by executables as handlers(what whitebox-controller have today, to be clear).