### PR TITLE
Allows empty group for webhook URL

### DIFF
--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -164,7 +164,11 @@ func wrap(h http.Handler) http.Handler {
 }
 
 func getBasePath(gvk schema.GroupVersionKind) string {
-	return fmt.Sprintf("/%s/%s/%s", gvk.Group, gvk.Version, strings.ToLower(gvk.Kind))
+	if gvk.Group == "" {
+		return fmt.Sprintf("/%s/%s", gvk.Version, strings.ToLower(gvk.Kind))
+	} else {
+		return fmt.Sprintf("/%s/%s/%s", gvk.Group, gvk.Version, strings.ToLower(gvk.Kind))
+	}
 }
 
 func newValidationHook(hc *config.HandlerConfig) (http.Handler, error) {


### PR DESCRIPTION
In cases where there's no group (i.e. namespaces, pod) the webhook url is built with double `//`, causing a redirect to single `/`, thus returning 404:

```
$ curl -vkL https://getup-controller.getup.svc:443//v1/namespace/validate
* About to connect() to getup-controller.getup.svc port 443 (#0)
*   Trying 172.30.216.38...
* Connected to getup-controller.getup.svc (172.30.216.38) port 443 (#0)
* Initializing NSS with certpath: sql:/etc/pki/nssdb
* skipping SSL peer certificate verification
* SSL connection using TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
* Server certificate:
* 	subject: CN=getup-controller.getup.svc
* 	start date: Aug 28 18:43:58 2019 GMT
* 	expire date: Aug 27 18:43:59 2021 GMT
* 	common name: getup-controller.getup.svc
* 	issuer: CN=openshift-service-serving-signer@1556681683
> GET //v1/namespace/validate HTTP/1.1
> User-Agent: curl/7.29.0
> Host: getup-controller.getup.svc
> Accept: */*
>
< HTTP/1.1 301 Moved Permanently
< Content-Type: text/html; charset=utf-8
< Location: /v1/namespace/validate
< Date: Wed, 28 Aug 2019 19:50:07 GMT
< Content-Length: 57
<
* Ignoring the response-body
* Connection #0 to host getup-controller.getup.svc left intact
* Issue another request to this URL: 'https://getup-controller.getup.svc:443/v1/namespace/validate'
* Found bundle for host getup-controller.getup.svc: 0x935f20
* Re-using existing connection! (#0) with host getup-controller.getup.svc
* Connected to getup-controller.getup.svc (172.30.216.38) port 443 (#0)
> GET /v1/namespace/validate HTTP/1.1
> User-Agent: curl/7.29.0
> Host: getup-controller.getup.svc
> Accept: */*
>
< HTTP/1.1 404 Not Found
< Content-Type: text/plain; charset=utf-8
< X-Content-Type-Options: nosniff
< Date: Wed, 28 Aug 2019 19:50:07 GMT
< Content-Length: 19
<
404 page not found
* Connection #0 to host getup-controller.getup.svc left intact
```