### PR TITLE
Missing trailing '/' for docker build COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN curl -L -o /tmp/download-binaries.sh https://raw.githubusercontent.com/kuber
   && /tmp/download-binaries.sh /usr/local/kubebuilder/bin
 
 WORKDIR /go/src/github.com/summerwind/whitebox-controller
-COPY go.mod go.sum .
+COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . /workspace


### PR DESCRIPTION
```
$ docker build . -t summerwind/whitebox-controller:patch-1
Sending build context to Docker daemon  554.5kB
Step 1/25 : FROM golang:1.12 AS build
 ---> 80bb9c6de3f2
Step 2/25 : ENV GO111MODULE=on     GOPROXY=https://proxy.golang.org
 ---> Using cache
 ---> 03f4ef625620
Step 3/25 : RUN curl -L -o /tmp/download-binaries.sh https://raw.githubusercontent.com/kubernetes-sigs/testing_frameworks/master/integration/scripts/download-binaries.sh   && chmod +x /tmp/download-binaries.sh   && mkdir -p /usr/local/kubebuilder/bin   && /tmp/download-binaries.sh /usr/local/kubebuilder/bin
 ---> Using cache
 ---> e47734f5bc71
Step 4/25 : WORKDIR /go/src/github.com/summerwind/whitebox-controller
 ---> Using cache
 ---> 129f253fd6d3
Step 5/25 : COPY go.mod go.sum .
When using COPY with more than one source file, the destination must be a directory and end with a /
```