### PR TITLE
References namespace matching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN curl -L -o /tmp/download-binaries.sh https://raw.githubusercontent.com/kuber
   && /tmp/download-binaries.sh /usr/local/kubebuilder/bin
 
 WORKDIR /go/src/github.com/summerwind/whitebox-controller
-COPY go.mod go.sum .
+COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . /workspace

--- a/config/config.go
+++ b/config/config.go
@@ -149,6 +149,7 @@ func (c *DependentConfig) Validate() error {
 type ReferenceConfig struct {
 	schema.GroupVersionKind
 	NameFieldPath string `json:"nameFieldPath"`
+	NamespaceFieldPath string `json:"namespaceFieldPath,omitempty"`
 }
 
 func (c *ReferenceConfig) Validate() error {

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -714,7 +714,7 @@ func TestIsDeleting(t *testing.T) {
 	rc := newResourceConfig()
 	object := newObject(rc.GroupVersionKind, "test")
 	deleting := newObject(rc.GroupVersionKind, "test")
-	SetNestedField(deleting.Object, string(time.Now().Unix()), "metadata", "deletionTimestamp")
+	SetNestedField(deleting.Object, fmt.Sprint(time.Now().Unix()), "metadata", "deletionTimestamp")
 
 	Expect(isDeleting(object)).To(BeFalse())
 	Expect(isDeleting(deleting)).To(BeTrue())


### PR DESCRIPTION
This PR adds new field References.NamespaceFieldPath in order to match objects from arbitrary namespaces.
It will only succeed if both name and namespace come in pairs.

The usage scenario is when one needs to fetch namespaced object reference from a different state object or cluster-wide objects like PersistentVolumes:

Referencing configmaps from namespace:

```
resources:
- group: ""
  version: v1
  kind: PersistentVolume
  reconciler:
    exec:
      command: /app/reconciler.py
  references:
  - group: ""
    version: v1
    kind: PersistentVolumeClaim
    nameFieldPath: ".spec.claimRef.name"
    namespaceFieldPath: ".spec.claimRef.namespace"
```

Referencing configmaps from other namespace:

```
resources:
- group: whitebox.summerwind.dev
  version: v1alpha1
  kind: Hello

  - group: ""
    version: v1
    kind: ConfigMap
    nameFieldPath: ".spec.configMapRef.name"
    namespaceFieldPath: ".spec.configMapRef..namespace"
```
